### PR TITLE
Fix toolchain package names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ nixpkgs_package(
     repository = "@nixpkgs",
 )
 register_toolchains(
-    "@misc_rules//toolchains:shellcheck_from_nixpkgs",
+    "@misc_rules//toolchains/shellcheck:shellcheck_from_nixpkgs",
 )
 ```
 
@@ -36,7 +36,7 @@ register_toolchains(
 
 ``` python
 register_toolchains(
-    "@misc_rules//toolchains:shellcheck_from_host_path",
+    "@misc_rules//toolchains/shellcheck:shellcheck_from_host_path",
 )
 ```
 
@@ -102,7 +102,7 @@ nixpkgs_package(
     repository = "@nixpkgs",
 )
 register_toolchains(
-    "@misc_rules//toolchains:yamllint_from_nixpkgs",
+    "@misc_rules//toolchains/yamllint:yamllint_from_nixpkgs",
 )
 ```
 


### PR DESCRIPTION
I think the toolchain package name described in README is wrong.

Related issue: https://github.com/andyscott/misc_rules/issues/12